### PR TITLE
Se agregan los campos createdAt, updatedAt, requeridos por la API RES…

### DIFF
--- a/src/main/java/com/mifiel/api/objects/Viewer.java
+++ b/src/main/java/com/mifiel/api/objects/Viewer.java
@@ -28,6 +28,12 @@ public class Viewer {
     @JsonProperty("certificate_number")
     private String certificate_number;
 
+    @JsonProperty("created_at")
+    private String createdAt;
+    
+    @JsonProperty("updated_at")
+    private String updatedAt;
+    
     public String getId() {
         return id;
     }
@@ -67,4 +73,22 @@ public class Viewer {
     public void setCertificate_number(String certificate_number) {
         this.certificate_number = certificate_number;
     }
+
+	public String getCreatedAt() {
+		return createdAt;
+	}
+
+	public void setCreatedAt(String createdAt) {
+		this.createdAt = createdAt;
+	}
+
+	public String getUpdatedAt() {
+		return updatedAt;
+	}
+
+	public void setUpdatedAt(String updatedAt) {
+		this.updatedAt = updatedAt;
+	}
+    
+    
 }


### PR DESCRIPTION
Se agregan los campos createdAt, updatedAt, requeridos por la API REST/JSON al objeto com.mifiel.api.objects.Viewer, sin éstos campos se genera un error, al crear un documento o listarlo, cuando se han agregado espectadores a la firma del documento.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Viewer objects now include timestamp fields for creation and update dates, allowing you to see when records were created and last modified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mifiel/java-api-client/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->